### PR TITLE
Routes for tags & notes; singlenote view updates after click (closes 47)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 public
 .DS_Store
 coverage
+notes/commit.txt

--- a/browser/js/common/directives/navbar/navbar.controller.js
+++ b/browser/js/common/directives/navbar/navbar.controller.js
@@ -1,6 +1,34 @@
 app.controller('NavbarCtrl', function($scope, NotesFactory) {
-	$scope.notes = NotesFactory.notes;
-})
+
+    // this piece is not working.
+    // how to get current notes that are in a parent scope?
+
+    $scope.notes = [
+    {
+        "subject": "dolor, nonummy ac,",
+        "body": "sollicitudin commodo ipsum. Suspendisse non leo. Vivamus nibh dolor, nonummy ac, feugiat non, lobortis quis, pede. Suspendisse dui. Fusce diam nunc, ullamcorper eu, euismod ac, fermentum vel, mauris. Integer sem elit, pharetra ut, pharetra sed, hendrerit a, arcu. Sed et libero. Proin mi. Aliquam gravida mauris ut mi. Duis risus odio, auctor vitae, aliquet nec, imperdiet nec, leo. Morbi neque tellus, imperdiet non, vestibulum nec, euismod in, dolor. Fusce feugiat. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam auctor, velit eget laoreet posuere, enim nisl elementum purus, accumsan interdum",
+        "size": 55,
+        "tags": ["orange"],
+        "dateCreated": "1443597123",
+        "lastUpdate": "1436909663"
+    },
+    {
+        "subject": "nec mauris blandit",
+        "body": "sed tortor. Integer aliquam adipiscing lacus. Ut nec urna et arcu imperdiet ullamcorper. Duis at lacus. Quisque purus sapien, gravida non, sollicitudin a, malesuada id, erat. Etiam vestibulum massa rutrum magna. Cras convallis convallis dolor. Quisque tincidunt pede ac urna. Ut tincidunt vehicula risus. Nulla eget metus eu erat semper rutrum. Fusce dolor quam, elementum at, egestas a, scelerisque sed, sapien. Nunc pulvinar arcu et pede. Nunc sed orci lobortis augue scelerisque mollis. Phasellus libero mauris, aliquam eu, accumsan sed, facilisis vitae, orci. Phasellus dapibus quam quis diam. Pellentesque",
+        "size": 95,
+        "tags": ["yellow"],
+        "dateCreated": "1431964328",
+        "lastUpdate": "1426507385"
+    },
+    {
+        "subject": "eu, euismod ac,",
+        "body": "congue. In scelerisque scelerisque dui. Suspendisse ac metus vitae velit egestas lacinia. Sed congue, elit sed consequat auctor, nunc nulla vulputate dui, nec tempus mauris erat eget ipsum. Suspendisse sagittis. Nullam vitae diam. Proin dolor. Nulla semper tellus id nunc interdum feugiat. Sed nec metus facilisis lorem tristique aliquet. Phasellus fermentum convallis ligula. Donec luctus aliquet odio. Etiam ligula tortor, dictum eu, placerat eget, venenatis a, magna. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Etiam laoreet, libero et",
+        "size": 89,
+        "tags": ["red"],
+        "dateCreated": "1451088738",
+        "lastUpdate": "1442746785"
+    }]
+});
 
 app.filter('trunc', function () {
         return function (value, wordwise, max, tail) {

--- a/browser/js/notes/notes.controller.js
+++ b/browser/js/notes/notes.controller.js
@@ -1,19 +1,19 @@
-app.controller('NotesCtrl', function($scope, AuthService, myNotebooks, NotesFactory, $rootScope) {
+app.controller('NotesCtrl', function($scope, AuthService, myNotebooks, NotesFactory, $rootScope, myTags, mySharedNotebooks) {
 
 	$scope.user = null;
 
-    // Tags and notes are hard-coded for now.
+    // Notes are hard-coded for now.
     // This will need to be modified!
-    $scope.tags = NotesFactory.tags;
     $scope.notes = NotesFactory.notes;
+
+    // promises
+    $scope.tags = myTags;
+    $scope.sharednotebooks = mySharedNotebooks;
+    $scope.notebooks = myNotebooks;
 
     // set the 'current note' to item 0 in the array by default. 
     // This will be changed later in sidenav.html and the sidenav controller.
     $rootScope.currentNote = $scope.notes[0];
-
-    // This is a promise that retrieves all notebooks for the
-    // currently logged-in user.
-    $scope.notebooks = myNotebooks;
 
 	$scope.isLoggedIn = function () {
 		return AuthService.isAuthenticated();

--- a/browser/js/notes/notes.controller.js
+++ b/browser/js/notes/notes.controller.js
@@ -1,18 +1,15 @@
-app.controller('NotesCtrl', function($scope, AuthService, myNotebooks, NotesFactory, $rootScope, myTags, mySharedNotebooks) {
+app.controller('NotesCtrl', function($scope, AuthService, myNotebooks, NotesFactory, $rootScope, myTags, mySharedNotebooks, myNotes) {
 
 	$scope.user = null;
 
-    // Notes are hard-coded for now.
-    // This will need to be modified!
-    $scope.notes = NotesFactory.notes;
-
     // promises
+    $scope.notes = myNotes;
     $scope.tags = myTags;
     $scope.sharednotebooks = mySharedNotebooks;
     $scope.notebooks = myNotebooks;
 
     // set the 'current note' to item 0 in the array by default. 
-    // This will be changed later in sidenav.html and the sidenav controller.
+    // not sure if this logic is correct.
     $rootScope.currentNote = $scope.notes[0];
 
 	$scope.isLoggedIn = function () {

--- a/browser/js/notes/notes.factory.js
+++ b/browser/js/notes/notes.factory.js
@@ -14,6 +14,17 @@ app.factory('NotesFactory', function($http) {
 		})
 	}
 
+	NotesFactory.fetchMySharedNotebooks = function(userId) {
+		console.log("notesfactory. fetching share notebooks for", userId)
+		return $http.get('/api/users/' + userId + '/notebooks/shared')
+		.then(function(response) {
+			console.log("fetched shared notebooks", response.data)
+			return response.data;
+		}, function(err) {
+			console.error("notesfactory. could not fetch shared notebooks for user", userId)
+		})
+	}
+
 	// As soon as the "get all notes for one user" route is finished, the next function can be un-commented.
 
 	// NotesFactory.fetchMyNotes = function(id) {
@@ -24,21 +35,16 @@ app.factory('NotesFactory', function($http) {
 
 	// }
 
-
-	// temporarily hard-coding tags.
-	NotesFactory.tags = ["orange","yellow","red","green","violet"]
-
-	// As soon as the "get all tags for one user" route is finished, this next function can be un-commented
-
-	// NotesFactory.fetchMyTags = function(id) {
-	// 	return $http.get('/api/users/'+ id + '/notebooks/own')
-	// 	.then(function(response) {
-	// 		// console.log("got notebook data", response.data)
-	// 		return response.data;
-	// 	}, function(err) {
-	// 		console.error("could not fetch notebooks for user",id)
-	// 	})	
-	// }
+	// this function is working!
+	NotesFactory.fetchMyTags = function(userId) {
+		return $http.get('/api/users/'+ userId + '/tags')
+		.then(function(response) {
+			// console.log("got tag data", response.data)
+			return response.data;
+		}, function(err) {
+			console.error("could not fetch tags for user",userId)
+		})	
+	}
 
 	// temporarily hard-coding notes.
 	NotesFactory.notes = [

--- a/browser/js/notes/notes.factory.js
+++ b/browser/js/notes/notes.factory.js
@@ -15,25 +15,23 @@ app.factory('NotesFactory', function($http) {
 	}
 
 	NotesFactory.fetchMySharedNotebooks = function(userId) {
-		console.log("notesfactory. fetching share notebooks for", userId)
+		// console.log("notesfactory. fetching share notebooks for", userId)
 		return $http.get('/api/users/' + userId + '/notebooks/shared')
 		.then(function(response) {
-			console.log("fetched shared notebooks", response.data)
+			// console.log("fetched shared notebooks", response.data)
 			return response.data;
 		}, function(err) {
 			console.error("notesfactory. could not fetch shared notebooks for user", userId)
 		})
 	}
 
-	// As soon as the "get all notes for one user" route is finished, the next function can be un-commented.
+	NotesFactory.fetchMyNotes = function(userId) {
+		return $http.get('/api/users/'+ userId + '/usernotes')
+		.then(function(response) {
+			return response.data;
+		})
 
-	// NotesFactory.fetchMyNotes = function(id) {
-	// 	return $http.get('/api/users/'+ id + '/notebooks')
-	// 	.then(function(response) {
-	// 		return response.data;
-	// 	})
-
-	// }
+	}
 
 	// this function is working!
 	NotesFactory.fetchMyTags = function(userId) {
@@ -46,67 +44,19 @@ app.factory('NotesFactory', function($http) {
 		})	
 	}
 
-	// temporarily hard-coding notes.
-	NotesFactory.notes = [
-		{
-			"_id" : "001",
-			"subject": "dolor, nonummy ac,",
-			"body": "sollicitudin commodo ipsum. Suspendisse non leo. Vivamus nibh dolor, nonummy ac, feugiat non, lobortis quis, pede. Suspendisse dui. Fusce diam nunc, ullamcorper eu, euismod ac, fermentum vel, mauris. Integer sem elit, pharetra ut, pharetra sed, hendrerit a, arcu. Sed et libero. Proin mi. Aliquam gravida mauris ut mi. Duis risus odio, auctor vitae, aliquet nec, imperdiet nec, leo. Morbi neque tellus, imperdiet non, vestibulum nec, euismod in, dolor. Fusce feugiat. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam auctor, velit eget laoreet posuere, enim nisl elementum purus, accumsan interdum",
-			"size": 55,
-			"tags": ["orange"],
-			"dateCreated": "1443597123",
-			"lastUpdate": "1436909663"
+	NotesFactory.getNote = function (noteId) {
+		return $http.get('/api/note/' + noteId)
+		.then(function(response) {
+			return response.data;
 		},
-		{
-			"_id" : "002",
-			"subject": "nec mauris blandit",
-			"body": "sed tortor. Integer aliquam adipiscing lacus. Ut nec urna et arcu imperdiet ullamcorper. Duis at lacus. Quisque purus sapien, gravida non, sollicitudin a, malesuada id, erat. Etiam vestibulum massa rutrum magna. Cras convallis convallis dolor. Quisque tincidunt pede ac urna. Ut tincidunt vehicula risus. Nulla eget metus eu erat semper rutrum. Fusce dolor quam, elementum at, egestas a, scelerisque sed, sapien. Nunc pulvinar arcu et pede. Nunc sed orci lobortis augue scelerisque mollis. Phasellus libero mauris, aliquam eu, accumsan sed, facilisis vitae, orci. Phasellus dapibus quam quis diam. Pellentesque",
-			"size": 95,
-			"tags": ["yellow"],
-			"dateCreated": "1431964328",
-			"lastUpdate": "1426507385"
-		},
-		{
-			"_id" : "003",
-			"subject": "eu, euismod ac,",
-			"body": "congue. In scelerisque scelerisque dui. Suspendisse ac metus vitae velit egestas lacinia. Sed congue, elit sed consequat auctor, nunc nulla vulputate dui, nec tempus mauris erat eget ipsum. Suspendisse sagittis. Nullam vitae diam. Proin dolor. Nulla semper tellus id nunc interdum feugiat. Sed nec metus facilisis lorem tristique aliquet. Phasellus fermentum convallis ligula. Donec luctus aliquet odio. Etiam ligula tortor, dictum eu, placerat eget, venenatis a, magna. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Etiam laoreet, libero et",
-			"size": 89,
-			"tags": ["red"],
-			"dateCreated": "1451088738",
-			"lastUpdate": "1442746785"
-		},
-		{
-			"_id" : "004",
-			"subject": "Maecenas libero est,",
-			"body": "et, lacinia vitae, sodales at, velit. Pellentesque ultricies dignissim lacus. Aliquam rutrum lorem ac risus. Morbi metus. Vivamus euismod urna. Nullam lobortis quam a felis ullamcorper viverra. Maecenas iaculis aliquet diam. Sed diam lorem, auctor quis, tristique ac, eleifend vitae, erat. Vivamus nisi. Mauris nulla. Integer urna. Vivamus molestie dapibus ligula. Aliquam erat volutpat. Nulla dignissim. Maecenas ornare egestas ligula. Nullam feugiat placerat velit. Quisque varius. Nam porttitor scelerisque neque. Nullam nisl. Maecenas malesuada fringilla est. Mauris eu turpis. Nulla aliquet. Proin velit. Sed malesuada augue ut lacus. Nulla tincidunt, neque vitae semper egestas, urna justo",
-			"size": 85,
-			"tags": ["yellow"],
-			"dateCreated": "1430325491",
-			"lastUpdate": "1436728534"
-		},
-		{
-			"_id" : "005",
-			"subject": "sed, est. Nunc",
-			"body": "a odio semper cursus. Integer mollis. Integer tincidunt aliquam arcu. Aliquam ultrices iaculis odio. Nam interdum enim non nisi. Aenean eget metus. In nec orci. Donec nibh. Quisque nonummy ipsum non arcu. Vivamus sit amet risus. Donec egestas. Aliquam nec enim. Nunc ut erat. Sed nunc est, mollis non, cursus non, egestas a, dui. Cras pellentesque. Sed dictum. Proin eget odio. Aliquam vulputate ullamcorper magna. Sed eu eros. Nam consequat dolor vitae dolor. Donec fringilla. Donec feugiat metus sit amet ante. Vivamus non lorem vitae odio sagittis semper. Nam tempor diam dictum sapien.",
-			"size": 82,
-			"tags": ["yellow"],
-			"dateCreated": "1434187023",
-			"lastUpdate": "1445510773"
-		},
-		{
-			"_id" : "006",
-			"subject": "nulla. Cras eu",
-			"body": "lorem lorem, luctus ut, pellentesque eget, dictum placerat, augue. Sed molestie. Sed id risus quis diam luctus lobortis. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos hymenaeos. Mauris ut quam vel sapien imperdiet ornare. In faucibus. Morbi vehicula. Pellentesque tincidunt tempus risus. Donec egestas. Duis ac arcu. Nunc mauris. Morbi non sapien molestie orci tincidunt adipiscing. Mauris molestie pharetra nibh. Aliquam ornare, libero at auctor ullamcorper, nisl arcu iaculis enim, sit amet ornare lectus justo eu arcu. Morbi sit amet massa. Quisque porttitor eros nec tellus. Nunc lectus pede, ultrices a, auctor non, feugiat nec, diam.",
-			"size": 62,
-			"tags": ["green"],
-			"dateCreated": "1443720520",
-			"lastUpdate": "1429268890"
-		}]
+		function(err) {
+			console.error("could not find note", err)
+		})
+	}
 
 
-
-
-	// The following function needs reworking. It might not be usable at all.
+	// I want to populate the note titles that are displayed below notebooks
+	// in the sidenav. How to do that?
 	
 	// NotesFactory.getNotesInOneNotebook = function(userId, notebookId) {
 	// 	return $http.get('/api/' + userId + '/notebooks/' + notebookId + '/notes')
@@ -117,11 +67,6 @@ app.factory('NotesFactory', function($http) {
 	// 		console.error("could not fetch note for user", userId, "notebook", notebookId)
 	// 	})
 	// }
-
-	
-
-
-
 
 	return NotesFactory; 
 })

--- a/browser/js/notes/notes.state.js
+++ b/browser/js/notes/notes.state.js
@@ -1,4 +1,5 @@
 app.config(function ($stateProvider) {
+	var iAm;
 
 	// this is the main state to show user content.
 	$stateProvider.state('usercontent', {
@@ -7,7 +8,6 @@ app.config(function ($stateProvider) {
 		controller: 'NotesCtrl',
 		resolve: {
 			myNotebooks: function(NotesFactory,AuthService) {
-				var iAm;
 				return AuthService.getLoggedInUser()
 				.then(function(user) {
 					iAm = user;
@@ -17,6 +17,30 @@ app.config(function ($stateProvider) {
 				.then(function() {
 					// console.log("usercontent state. fetching notes for",iAm._id)
 					return NotesFactory.fetchMyNotebooks(iAm._id)
+				})
+			},
+			mySharedNotebooks: function(NotesFactory,AuthService) {
+				return AuthService.getLoggedInUser()
+				.then(function(user) {
+					iAm = user;
+				}, function(err) {
+					console.error("Error retrieving user!", err)
+				})
+				.then(function() {
+					console.log("usercontent state. fetching sharednotebooks for",iAm._id)
+					return NotesFactory.fetchMySharedNotebooks(iAm._id)
+				})
+			},
+			myTags: function(NotesFactory,AuthService) {
+				return AuthService.getLoggedInUser()
+				.then(function(user) {
+					iAm = user;
+				}, function(err) {
+					console.error("Error retrieving user!", err)
+				})
+				.then(function() {
+					// console.log("usercontent state. fetching tags for",iAm._id)
+					return NotesFactory.fetchMyTags(iAm._id)
 				})
 			}
 		}

--- a/browser/js/notes/notes.state.js
+++ b/browser/js/notes/notes.state.js
@@ -27,8 +27,8 @@ app.config(function ($stateProvider) {
 					console.error("Error retrieving user!", err)
 				})
 				.then(function() {
-					console.log("usercontent state. fetching sharednotebooks for",iAm._id)
-					return NotesFactory.fetchMySharedNotebooks(iAm._id)
+					// console.log("usercontent state. fetching sharednotebooks for",iAm._id)
+					return NotesFactory.fetchMySharedNotebooks(iAm._id);
 				})
 			},
 			myTags: function(NotesFactory,AuthService) {
@@ -40,7 +40,16 @@ app.config(function ($stateProvider) {
 				})
 				.then(function() {
 					// console.log("usercontent state. fetching tags for",iAm._id)
-					return NotesFactory.fetchMyTags(iAm._id)
+					return NotesFactory.fetchMyTags(iAm._id);
+				})
+			},
+			myNotes: function(NotesFactory, AuthService) {
+				return AuthService.getLoggedInUser()
+				.then(function(user) {
+					iAm = user;
+				})
+				.then(function() {
+					return NotesFactory.fetchMyNotes(iAm._id);
 				})
 			}
 		}

--- a/browser/js/notes/sidenav/sidenav.controller.js
+++ b/browser/js/notes/sidenav/sidenav.controller.js
@@ -1,10 +1,17 @@
-app.controller('SidenavCtrl', function($scope, $rootScope) {
+app.controller('SidenavCtrl', function($scope, $rootScope, NotesFactory) {
 
-	// Eventually this next function needs to be hooked up to switch the current note to the parameter passed.
-	// I suspect we will need to have a cache of all notes for this user.
+	// We may want to create a cache of all notes for this user to avoid repeated DB calls
+
+	// change the current note displayed in singlenote.html to the note that the user clicked in sidenav
 	$scope.switchCurrentNote = function(noteId) {
-		console.log("you clicked note", noteId)
-		$rootScope.currentNote = noteId;
-		console.log("rootscope current note is now", $rootScope.currentNote);
+		// console.log("you clicked note", noteId)
+
+		NotesFactory.getNote(noteId)
+		.then(function(theNote) {
+			// is there a better way to do this, besides rootScope?
+			$rootScope.currentNote = theNote;
+			// console.log("rootscope current note is now", $rootScope.currentNote);
+		})
+	
 	}
 })

--- a/browser/js/notes/sidenav/sidenav.html
+++ b/browser/js/notes/sidenav/sidenav.html
@@ -62,8 +62,20 @@
 						<div class="panel-heading">My Shared Notebooks</div>
 						<div class="panel-body">
 							<div class="list-group" id="side-menu-4">
-								<!-- this needs to be changed to sharednotebook in sharednotebooks -->
-								<a class="list-group-item" ng-repeat="notebook in notebooks">{{notebook.title}}</a>
+
+								<div ng-repeat="sharednotebook in sharednotebooks">
+									<a data-toggle="collapse" ng-href="#{{sharednotebook._id}}" class="list-group-item">{{sharednotebook.title}}</a>
+									<div class="panel-collapse collapse" id="{{sharednotebook._id}}">
+										<div class="panel-body">
+											<div class="list-group">
+												<a ng-click="switchCurrentNote(oneNote)" class="list-group-item" ng-repeat="oneNote in sharednotebook.notes">{{oneNote}}
+												</a>
+											</div>
+										</div>
+									</div>
+								</div>
+
+<!-- 								<a class="list-group-item" ng-repeat="sharednotebook in sharednotebooks">{{sharednotebook.title}}</a> -->
 							</div>
 						</div>
 					</div>

--- a/browser/js/notes/sidenav/sidenav.html
+++ b/browser/js/notes/sidenav/sidenav.html
@@ -20,7 +20,7 @@
 						<div class="panel-heading">My Notes</div>
 						<div class="panel-body">
 							<div class='list-group' id="side-menu-1">
-								<a class="list-group-item" ng-repeat="note in notes">{{note.subject}}</a>
+								<a ng-click="switchCurrentNote(note)" class="list-group-item" ng-repeat="note in notes">{{note.subject}}</a>
 							</div>
 						</div>
 					</div>
@@ -74,8 +74,6 @@
 										</div>
 									</div>
 								</div>
-
-<!-- 								<a class="list-group-item" ng-repeat="sharednotebook in sharednotebooks">{{sharednotebook.title}}</a> -->
 							</div>
 						</div>
 					</div>

--- a/browser/js/notes/singlenote/singlenote.controller.js
+++ b/browser/js/notes/singlenote/singlenote.controller.js
@@ -1,15 +1,3 @@
-app.controller('SingleNoteCtrl', function($scope) {
+app.controller('SingleNoteCtrl', function($scope, $rootScope) {
 
-	// Hard-coding a note here for now.
-	// Eventually we will want to toggle the display of the note
-	// based on what the user clicks in the sidenav.
-	$scope.note = 	{
-		"_id": "205",
-		"subject": "dolor, nonummy ac,",
-		"body": "sollicitudin commodo ipsum. Suspendisse non leo. Vivamus nibh dolor, nonummy ac, feugiat non, lobortis quis, pede. Suspendisse dui. Fusce diam nunc, ullamcorper eu, euismod ac, fermentum vel, mauris. Integer sem elit, pharetra ut, pharetra sed, hendrerit a, arcu. Sed et libero. Proin mi. Aliquam gravida mauris ut mi. Duis risus odio, auctor vitae, aliquet nec, imperdiet nec, leo. Morbi neque tellus, imperdiet non, vestibulum nec, euismod in, dolor. Fusce feugiat. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam auctor, velit eget laoreet posuere, enim nisl elementum purus, accumsan interdum",
-		"size": 55,
-		"tags": ["orange","red","blue"],
-		"dateCreated": "1443597123",
-		"lastUpdate": "1436909663"
-	}
 })

--- a/browser/js/notes/singlenote/singlenote.html
+++ b/browser/js/notes/singlenote/singlenote.html
@@ -1,33 +1,32 @@
 <div class="col-lg-8 col-md-8 col-sm-12">
-
 	<div class="panel panel-default">
-	<div class="panel-heading"><h3>{{note.subject}}</h3></div>
+	<div class="panel-heading"><h3>{{currentNote.subject}}</h3></div>
 		<div class="panel-body">
 			<div class="panel panel-default">
 				<div class="panel-heading">
 				<h4 class="panel-title">
-				<a data-toggle="collapse" data-parent="#accordion" ng-href="#{{note._id}}">Note details</a>
+				<a data-toggle="collapse" data-parent="#accordion" ng-href="#{{currentNote._id}}">Note details</a>
 				</h4>
 				</div>
-				<div id="{{note._id}}" class="panel-collapse collapse">
+				<div id="{{currentNote._id}}" class="panel-collapse collapse">
 					<div class="panel-body">
-						<div class="col-lg-4">Size: {{note.size}} kb</div>
+						<div class="col-lg-4">Size: {{currentNote.size}} kb</div>
 
-						<div class="col-lg-4">Created: {{note.dateCreated | date : 'short'}}</div>
-						<div class="col-lg-4">Last updated: {{note.lastUpdate | date : 'short'}}</div>
+						<div class="col-lg-4">Created: {{currentNote.dateCreated | date : 'short'}}</div>
+						<div class="col-lg-4">Last updated: {{currentNote.lastUpdate | date : 'short'}}</div>
 					</div>
 				</div>
 			</div>
-			<div>{{note.body}}</div>
+			<div>{{currentNote.body}}</div>
 			<!-- testing tonic dev -->
-			<h4>If tonic dev is working, code editor should appear here here: </h4>
+<!-- 			<h4>If tonic dev is working, code editor should appear here here: </h4>
 			<div style="border: 1px solid red" id="my-element">
 			</div>
-			<!-- end tonic dev test -->
+ -->			<!-- end tonic dev test -->
 		</div>
 		<div class="panel-footer">
 			<h4>Tags</h4>
-			<button ng-repeat="tag in note.tags" type="button" class="btn btn-outline btn-default" data-toggle="tooltip" title="Remove tag">{{tag}} x </button>
+			<button ng-repeat="tag in currentNote.tags" type="button" class="btn btn-outline btn-default" data-toggle="tooltip" title="Remove tag">{{tag}} x </button>
 			<button type="button" class="btn btn-success btn-circle"  data-toggle="tooltip" title="Add a tag">
 				<i class="fa fa-plus">
 				</i>

--- a/server/app/routes/index.js
+++ b/server/app/routes/index.js
@@ -8,6 +8,25 @@ router.use('/public', require('./public-data'));
 router.use('/notes', require('./notes'));
 
 
+// I am not sure where to put this route. 
+// It is a simplified way to reach one note.
+// I stored it in this file for now, but feel free to move to a different folder or file.
+// Sorry!
+
+var mongoose = require('mongoose');
+var Note = mongoose.model('Note');
+
+router.get('/note/:noteId', function(req,res) {
+	Note.findById(req.params.noteId)
+	.then(function(theNote) {
+		console.log("Found the note:", theNote)
+		res.json(theNote);
+	},
+	function(err) {
+		console.error("Could not find note",err)
+	})
+});
+
 
 // Make sure this is after all of
 // the registered routes!

--- a/server/app/routes/notes/notes.js
+++ b/server/app/routes/notes/notes.js
@@ -6,8 +6,11 @@ module.exports = router;
 var mongoose = require('mongoose');
 var Note = mongoose.model('Note');
 
+
+// Getting all notes for one user is being handled in routes/users/user.notes.js
+
 // Get all notes for the user
-router.get('/', function(req, res, next) {
+// router.get('/', function(req, res, next) {
 	
-})
+// })
 

--- a/server/app/routes/users/user.js
+++ b/server/app/routes/users/user.js
@@ -36,7 +36,12 @@ router.delete('/', function(req, res, next){
   .then(null, next);
 });
 
+// router.get('/notes', function(req, res, next){
+//   console.log("inside api users userid notes field", req.currentUser)
+//   res.send('hi');
+// });
+
 router.use('/notebooks', require('../notebooks'));
 router.use('/notes', require('../notes/notes.js'));
 router.use('/tags', require('./user.tags.js'));
-
+router.use('/notes', require('./user.notes.js'));

--- a/server/app/routes/users/user.js
+++ b/server/app/routes/users/user.js
@@ -36,12 +36,12 @@ router.delete('/', function(req, res, next){
   .then(null, next);
 });
 
-// router.get('/notes', function(req, res, next){
-//   console.log("inside api users userid notes field", req.currentUser)
-//   res.send('hi');
-// });
+router.get('/notes', function(req, res, next){
+  console.log("inside api users userid notes for", req.currentUser)
+  // res.send('hi');
+});
 
 router.use('/notebooks', require('../notebooks'));
 router.use('/notes', require('../notes/notes.js'));
 router.use('/tags', require('./user.tags.js'));
-router.use('/notes', require('./user.notes.js'));
+router.use('/usernotes', require('./user.notes.js'));

--- a/server/app/routes/users/user.js
+++ b/server/app/routes/users/user.js
@@ -37,5 +37,6 @@ router.delete('/', function(req, res, next){
 });
 
 router.use('/notebooks', require('../notebooks'));
- router.use('/notes', require('../notes/notes.js'));
+router.use('/notes', require('../notes/notes.js'));
+router.use('/tags', require('./user.tags.js'));
 

--- a/server/app/routes/users/user.notes.js
+++ b/server/app/routes/users/user.notes.js
@@ -1,0 +1,1 @@
+user.notes.js

--- a/server/app/routes/users/user.notes.js
+++ b/server/app/routes/users/user.notes.js
@@ -1,1 +1,59 @@
-user.notes.js
+//  Route /api/users/:userId/notes
+
+'use strict';
+var router = require('express').Router();
+module.exports = router;
+var mongoose = require('mongoose');
+// var User = mongoose.model('User');
+// var Notebook = mongoose.model('Notebook');
+// var Note = mongoose.model('Note');
+
+// Get all notes for one user
+// Note: this function should be rewritten because of callback hell.
+// I'm not sure how, though!
+// Error handling should also be improved.
+
+router.get('/', function(req, res, next){
+	console.log("inside api users userid notes field", req.currentUser)
+	// var multidimensionalArrayOfNodeIds = [], 
+	// 	arrayOfNoteIds = [], 
+	// 	multidimensionalArrayOfTags = [], 
+	// 	arrayOfTags = [];
+
+
+	res.json('hi');
+
+	// User.findOne(req.currentUser._id)
+	// .then(function(user) {
+
+		// Notebook.find({ 
+		// 	_id: { $in: req.currentUser.myNotebooks
+		//    }
+		// })
+		// .then(function(notebooks) {
+		// 	console.log("here are the notebooks:",notebooks);
+
+		// 	// get an array of only note Ids
+		//     multidimensionalArrayOfNodeIds = notebooks.map(function(element) { return element.notes })
+		    
+		//     // now reduce that to a one-dimensional list
+		//     arrayOfNoteIds = multidimensionalArrayOfNodeIds.reduce(function(a, b) {
+		//          return a.concat(b);
+		//         });
+
+		//     // find notes with those IDs
+		// 	Note.find({
+		// 		_id: {
+		// 			$in: arrayOfNoteIds
+		// 		}
+		// 	})
+		// 	.then(function(notes) {
+		// 		console.log("here are the notes:", notes)
+		// 	    res.json(notes);
+		// 	})
+		// })
+
+
+	// })
+});
+

--- a/server/app/routes/users/user.notes.js
+++ b/server/app/routes/users/user.notes.js
@@ -1,59 +1,42 @@
-//  Route /api/users/:userId/notes
+//  Route /api/users/:userId/usernotes
 
 'use strict';
 var router = require('express').Router();
 module.exports = router;
 var mongoose = require('mongoose');
-// var User = mongoose.model('User');
-// var Notebook = mongoose.model('Notebook');
-// var Note = mongoose.model('Note');
+var User = mongoose.model('User');
+var Notebook = mongoose.model('Notebook');
+var Note = mongoose.model('Note');
 
 // Get all notes for one user
-// Note: this function should be rewritten because of callback hell.
-// I'm not sure how, though!
-// Error handling should also be improved.
 
 router.get('/', function(req, res, next){
-	console.log("inside api users userid notes field", req.currentUser)
-	// var multidimensionalArrayOfNodeIds = [], 
-	// 	arrayOfNoteIds = [], 
-	// 	multidimensionalArrayOfTags = [], 
-	// 	arrayOfTags = [];
+	// console.log("inside api users userid notes field", req.currentUser)
+	var multidimensionalArrayOfNodeIds = [], 
+		arrayOfNoteIds = [], 
+		multidimensionalArrayOfTags = [], 
+		arrayOfTags = [];
 
+	// console.log("here are the notebooks:",req.currentUser.myNotebooks);
 
-	res.json('hi');
+	// get an array of only note Ids
+    multidimensionalArrayOfNodeIds = req.currentUser.myNotebooks.map(function(element) { return element.notes })
+    
+    // now reduce that to a one-dimensional list
+    arrayOfNoteIds = multidimensionalArrayOfNodeIds.reduce(function(a, b) {
+         return a.concat(b);
+        });
 
-	// User.findOne(req.currentUser._id)
-	// .then(function(user) {
+    // find notes with those IDs
+	Note.find({
+		_id: {
+			$in: arrayOfNoteIds
+		}
+	})
+	.then(function(notes) {
+		// console.log("here are the notes:", notes)
+	    res.json(notes);
+	})
 
-		// Notebook.find({ 
-		// 	_id: { $in: req.currentUser.myNotebooks
-		//    }
-		// })
-		// .then(function(notebooks) {
-		// 	console.log("here are the notebooks:",notebooks);
-
-		// 	// get an array of only note Ids
-		//     multidimensionalArrayOfNodeIds = notebooks.map(function(element) { return element.notes })
-		    
-		//     // now reduce that to a one-dimensional list
-		//     arrayOfNoteIds = multidimensionalArrayOfNodeIds.reduce(function(a, b) {
-		//          return a.concat(b);
-		//         });
-
-		//     // find notes with those IDs
-		// 	Note.find({
-		// 		_id: {
-		// 			$in: arrayOfNoteIds
-		// 		}
-		// 	})
-		// 	.then(function(notes) {
-		// 		console.log("here are the notes:", notes)
-		// 	    res.json(notes);
-		// 	})
-		// })
-
-
-	// })
 });
 

--- a/server/app/routes/users/user.tags.js
+++ b/server/app/routes/users/user.tags.js
@@ -9,9 +9,7 @@ var Notebook = mongoose.model('Notebook');
 var Note = mongoose.model('Note');
 
 // Get all tags for one user
-// Note: this function should be rewritten because of callback hell.
-// I'm not sure how, though!
-// Error handling should also be improved.
+// Error handling could be improved!
 
 router.get('/', function(req, res, next){
 	var multidimensionalArrayOfNodeIds = [], 
@@ -19,48 +17,36 @@ router.get('/', function(req, res, next){
 		multidimensionalArrayOfTags = [], 
 		arrayOfTags = [];
 
-	User.findOne(req.currentUser._id)
-	.then(function(user) {
-		Notebook.find({ 
-			_id: { $in: user.myNotebooks
-		   }
-		})
-		.then(function(notebooks) {
-			// console.log("here are the notebooks:",notebooks);
+    multidimensionalArrayOfNodeIds = req.currentUser.myNotebooks.map(function(element) { return element.notes })
+    
+    // now reduce that to a one-dimensional list
+    arrayOfNoteIds = multidimensionalArrayOfNodeIds.reduce(function(a, b) {
+         return a.concat(b);
+        });
 
-			// get an array of only note Ids
-		    multidimensionalArrayOfNodeIds = notebooks.map(function(element) { return element.notes })
-		    
-		    // now reduce that to a one-dimensional list
-		    arrayOfNoteIds = multidimensionalArrayOfNodeIds.reduce(function(a, b) {
-		         return a.concat(b);
-		        });
-
-		    // find notes with those IDs
-			Note.find({
-				_id: {
-					$in: arrayOfNoteIds
-				}
-			})
-			.then(function(notes) {
-				// console.log("here are the notes:", notes)
-				// get an array of array of tags
-			    multidimensionalArrayOfTags = notes.map(function(element) { return element.tags })
-			    
-			    // now reduce that to a one-dimensional list
-			    arrayOfTags = multidimensionalArrayOfTags.reduce(function(a, b) {
-			         return a.concat(b);
-			        });
+    // find notes with those IDs
+	Note.find({
+		_id: {
+			$in: arrayOfNoteIds
+		}
+	})
+	.then(function(notes) {
+		// console.log("here are the notes:", notes)
+		// get an array of array of tags
+	    multidimensionalArrayOfTags = notes.map(function(element) { return element.tags })
+	    
+	    // now reduce that to a one-dimensional list
+	    arrayOfTags = multidimensionalArrayOfTags.reduce(function(a, b) {
+	         return a.concat(b);
+	        });
 
 
-			    // sort and filter for unique values
-				arrayOfTags = arrayOfTags.sort().filter(function (e, i, arr) {
-					return arr.lastIndexOf(e) === i;
-				});
+	    // sort and filter for unique values
+		arrayOfTags = arrayOfTags.sort().filter(function (e, i, arr) {
+			return arr.lastIndexOf(e) === i;
+		});
 
-			    res.json(arrayOfTags);
-			})
-		})
+	    res.json(arrayOfTags);
 	})
 });
 

--- a/server/app/routes/users/user.tags.js
+++ b/server/app/routes/users/user.tags.js
@@ -12,6 +12,7 @@ var Note = mongoose.model('Note');
 // Note: this function should be rewritten because of callback hell.
 // I'm not sure how, though!
 // Error handling should also be improved.
+
 router.get('/', function(req, res, next){
 	var multidimensionalArrayOfNodeIds = [], 
 		arrayOfNoteIds = [], 
@@ -42,7 +43,7 @@ router.get('/', function(req, res, next){
 				}
 			})
 			.then(function(notes) {
-				console.log("here are the notes:", notes)
+				// console.log("here are the notes:", notes)
 				// get an array of array of tags
 			    multidimensionalArrayOfTags = notes.map(function(element) { return element.tags })
 			    

--- a/server/app/routes/users/user.tags.js
+++ b/server/app/routes/users/user.tags.js
@@ -1,0 +1,65 @@
+// Route /api/users/:userId/tags
+
+'use strict';
+var router = require('express').Router();
+module.exports = router;
+var mongoose = require('mongoose');
+var User = mongoose.model('User');
+var Notebook = mongoose.model('Notebook');
+var Note = mongoose.model('Note');
+
+// Get all tags for one user
+// Note: this function should be rewritten because of callback hell.
+// I'm not sure how, though!
+// Error handling should also be improved.
+router.get('/', function(req, res, next){
+	var multidimensionalArrayOfNodeIds = [], 
+		arrayOfNoteIds = [], 
+		multidimensionalArrayOfTags = [], 
+		arrayOfTags = [];
+
+	User.findOne(req.currentUser._id)
+	.then(function(user) {
+		Notebook.find({ 
+			_id: { $in: user.myNotebooks
+		   }
+		})
+		.then(function(notebooks) {
+			// console.log("here are the notebooks:",notebooks);
+
+			// get an array of only note Ids
+		    multidimensionalArrayOfNodeIds = notebooks.map(function(element) { return element.notes })
+		    
+		    // now reduce that to a one-dimensional list
+		    arrayOfNoteIds = multidimensionalArrayOfNodeIds.reduce(function(a, b) {
+		         return a.concat(b);
+		        });
+
+		    // find notes with those IDs
+			Note.find({
+				_id: {
+					$in: arrayOfNoteIds
+				}
+			})
+			.then(function(notes) {
+				console.log("here are the notes:", notes)
+				// get an array of array of tags
+			    multidimensionalArrayOfTags = notes.map(function(element) { return element.tags })
+			    
+			    // now reduce that to a one-dimensional list
+			    arrayOfTags = multidimensionalArrayOfTags.reduce(function(a, b) {
+			         return a.concat(b);
+			        });
+
+
+			    // sort and filter for unique values
+				arrayOfTags = arrayOfTags.sort().filter(function (e, i, arr) {
+					return arr.lastIndexOf(e) === i;
+				});
+
+			    res.json(arrayOfTags);
+			})
+		})
+	})
+});
+


### PR DESCRIPTION
_There may be merge conflicts. If so, let's discuss Monday morning!_
## Routes
- `/api/users/:userId/tags` fetches all tags for a user
- `/note/:noteId` fetches a note by ID
- `/api/users/:userId/usernotes` gets all notes for one user
## Front end: singlenote view
- If you click a note ID in the sidenav, the singlenote view updates to that note
## Sidenav
- Tags are now dynamically fetched for the current logged-in user
- Shared Notebooks are now dynamically fetched for the current logged-in user
- Notes are now dynamically fetched for the current logged-in user
## Remaining to be done:
- Grab actual three most recent notes to display in navbar (upper right). Right now, it's static data.
- Display the note subjects (instead of IDs) in the sidenav (under My Notebooks and Shared Notebooks)
- Troubleshoot why the Notes panel (in sidenav) is empty when you load the page 
- Find out how to make note data editable in singlenote view
