### PR TITLE
Add tag; remove ZenPen from note subject editing

### DIFF
--- a/browser/js/notes/notes.controller.js
+++ b/browser/js/notes/notes.controller.js
@@ -2,23 +2,12 @@ app.controller('NotesCtrl', function($scope, AuthService, myNotebooks, NotesFact
 
 	$scope.user = null;
 
-   // $scope.currentNote = currentNote;
-
     // promises
     $scope.notes = myNotes;
-        // $scope.notes = [{subject: 'hello'},{subject: 'bye'}];
 
     $scope.tags = myTags;
     $scope.sharednotebooks = mySharedNotebooks;
     $scope.notebooks = myNotebooks;
-
-    // set the 'current note' to item 0 in the array by default. 
-    // not sure if this logic is correct.
-    // $rootScope.currentNote = $scope.notes[0];
-    // $rootScope.currentNotebook = $scope.notebooks[0];
-    //console.log("this is myNote,", myNotes );
-    //console.log("this is", notesService);
-    //notesService.addAllnotes(myNotes);
 
 	$scope.isLoggedIn = function () {
 		return AuthService.isAuthenticated();

--- a/browser/js/notes/notes.factory.js
+++ b/browser/js/notes/notes.factory.js
@@ -258,7 +258,11 @@ app.factory('NotesFactory', function($http, $rootScope) {
 
 	NotesFactory.findParentNotebook = function(noteId) {
 		for (var i = 0; i < notebookCache.length; i++) {
-
+			for (var j = 0; j < notebookCache[i].notes.length; j++) {
+				if(notebookCache[i].notes[j]._id == noteId) {
+					return notebookCache[i]._id;
+				}
+			}
 		}
 	}
 

--- a/browser/js/notes/notes.factory.js
+++ b/browser/js/notes/notes.factory.js
@@ -110,6 +110,8 @@ app.factory('NotesFactory', function($http, $rootScope) {
 	// 		}
 	// 	}
 	// }
+
+
     
      NotesFactory.findNoteIndex = function(notebook, noteId) {
 		for (var i = 0; i < notebook.notes.length; i++) {
@@ -246,12 +248,18 @@ app.factory('NotesFactory', function($http, $rootScope) {
 
 	NotesFactory.addTag = function(noteId, tag) {
         NotesFactory.updateTagsCache(tag, 'add');
-		return $http.post('/api/note/' +  noteId + '/tags', {tag: tag});
+		return $http.post('/api/notes/' +  noteId + '/tags', {tag: tag});
 	}
 
 	NotesFactory.removeTag = function(noteId, tag) {
         NotesFactory.updateTagsCache(tag, 'delete');
-		return $http.put('/api/note/' +  noteId + '/tags', {tag: tag});
+		return $http.put('/api/notes/' +  noteId + '/tags', {tag: tag});
+	}
+
+	NotesFactory.findParentNotebook = function(noteId) {
+		for (var i = 0; i < notebookCache.length; i++) {
+
+		}
 	}
 
 

--- a/browser/js/notes/singlenote/singlenote.controller.js
+++ b/browser/js/notes/singlenote/singlenote.controller.js
@@ -26,6 +26,9 @@ app.controller('SingleNoteCtrl', function($scope, NotesFactory) {
 
         // update Notes cache
         NotesFactory.updateNoteInNotebookCache(currentNotebook, newNote, 'update');
+        
+        // generate success message
+        $scope.tagsavesuccess = "Tag saved successfully!";
 
       }, function(err) {
         console.error("error saving tag",err)

--- a/browser/js/notes/singlenote/singlenote.controller.js
+++ b/browser/js/notes/singlenote/singlenote.controller.js
@@ -44,24 +44,24 @@ app.controller('SingleNoteCtrl', function($scope, NotesFactory, TonicFactory) {
       var bodyToSave = $('#notebody').val();
       var currentNotebook;
 
-    $scope.savenote = {
-      "subject": subjectToSave,
-      "body": bodyToSave
-    }  
+      $scope.savenote = {
+        "subject": subjectToSave,
+        "body": bodyToSave
+      }  
 
-    NotesFactory.getCurrentNotebook()
-    .then(function(_currentNotebook){
-      currentNotebook = _currentNotebook;
+      NotesFactory.getCurrentNotebook()
+      .then(function(_currentNotebook){
+        currentNotebook = _currentNotebook;
+        })
+      .then(function(){
+        console.log("this is current Notebook, ", currentNotebook);
+        return NotesFactory.saveNote(currentNotebook._id,$scope.currentNote()._id, $scope.savenote)
       })
-    .then(function(){
-      console.log("this is current Notebook, ", currentNotebook);
-      return NotesFactory.saveNote(currentNotebook._id,$scope.currentNote()._id, $scope.savenote)
-    })
-    .then(function(note) {
-        $scope.successmessage="Note saved successfully!" + note;
-      }, function(err) {
-        $scope.errormessage = "Error saving note" + err;
-      })    
+      .then(function(note) {
+          $scope.successmessage="Note saved successfully!" + note;
+        }, function(err) {
+          $scope.errormessage = "Error saving note" + err;
+        })    
     }
 
     $scope.deleteNote = function(noteId) {

--- a/browser/js/notes/singlenote/singlenote.controller.js
+++ b/browser/js/notes/singlenote/singlenote.controller.js
@@ -40,7 +40,7 @@ app.controller('SingleNoteCtrl', function($scope, NotesFactory, TonicFactory) {
     }
 
     $scope.save = function(){ 
-      var subjectToSave = $('#notesubject').html();
+      var subjectToSave = $('#notesubject').val();
       var bodyToSave = $('#notebody').val();
       var currentNotebook;
 

--- a/browser/js/notes/singlenote/singlenote.controller.js
+++ b/browser/js/notes/singlenote/singlenote.controller.js
@@ -1,7 +1,7 @@
 app.controller('SingleNoteCtrl', function($scope, NotesFactory) {
   	$scope.savenote = {};
 	
-  	$scope.openTW = false
+  	$scope.showTagEditWindow = false
 
   	var stroutput = "";
     $scope.currentNote = NotesFactory.getCurrentNote;
@@ -14,54 +14,64 @@ app.controller('SingleNoteCtrl', function($scope, NotesFactory) {
     }
 
     $scope.addTag = function(noteId, tag) {
-      NotesFactory.addTag(noteId, tag);
-      $scope.openTW = false;
+      console.log("running addTag", noteId, tag)
+      NotesFactory.addTag(noteId, tag)
+      .then(function(newNote) {
+        console.log("saved note with new tag tag",newNote.data);
+
+        // update tags cache
+        NotesFactory.updateTagsCache(newNote.data.tags[newNote.data.tags.length - 1])
+
+        var currentNotebook = NotesFactory.findParentNotebook(noteId) 
+
+        // update Notes cache
+        NotesFactory.updateNoteInNotebookCache(currentNotebook, newNote, 'update');
+
+
+      }, function(err) {
+        console.error("error saving tag",err)
+      })
     }
 
     $scope.openTagWindow = function() {
-      $scope.openTW = !$scope.openTW;
+      $scope.showTagEditWindow = !$scope.showTagEditWindow;
     }
-
-     // $scope.save = NotesFactory.saveNote;
-
 
     $scope.save = function(){ 
       var subjectToSave = $('#notesubject').html();
-      // var bodyToSave = $('#notebody').html();
-      // var bodyToSave = $('#notebody > textarea').val();
       var bodyToSave = $('#notebody').val();
 
       $scope.savenote = {
         "subject": subjectToSave,
         "body": bodyToSave
       }
+
       $scope.currentNotebook = NotesFactory.getCurrentNotebook();
-      
+
       NotesFactory.saveNote($scope.currentNotebook._id, $scope.currentNote()._id, $scope.savenote)
       .then(function(note) {
-          $scope.successmessage="Note saved successfully!" + note;
+        $scope.successmessage="Note saved successfully!" + note;
         }, function(err) {
-          $scope.errormessage = "Error saving note" + err;
+        $scope.errormessage = "Error saving note" + err;
       })
     }
 
-  $scope.deleteNote = function(noteId) {
-    console.log("inside deleteNote")
-    NotesFactory.trashNote(noteId);
-  }
+    $scope.deleteNote = function(noteId) {
+      console.log("inside deleteNote")
+      NotesFactory.trashNote(noteId);
+    }
 
-  $scope.highlightPre = function() {
-    hljs.initHighlighting();
-  }
+    $scope.highlightPre = function() {
+      hljs.initHighlighting();
+    }
 
-  $scope.addPre = function() {
-    var domElement = $('#testdiv')[0];
-    var codeValue = domElement.innerHTML;
-    var preElement = $('<pre><code>' + codeValue + '</code></pre>');
-    $(domElement).replaceWith(preElement);
-    hljs.initHighlighting();
-
-  }
+    $scope.addPre = function() {
+      var domElement = $('#testdiv')[0];
+      var codeValue = domElement.innerHTML;
+      var preElement = $('<pre><code>' + codeValue + '</code></pre>');
+      $(domElement).replaceWith(preElement);
+      hljs.initHighlighting();
+    }
 
 
 })

--- a/browser/js/notes/singlenote/singlenote.controller.js
+++ b/browser/js/notes/singlenote/singlenote.controller.js
@@ -27,7 +27,6 @@ app.controller('SingleNoteCtrl', function($scope, NotesFactory) {
         // update Notes cache
         NotesFactory.updateNoteInNotebookCache(currentNotebook, newNote, 'update');
 
-
       }, function(err) {
         console.error("error saving tag",err)
       })

--- a/browser/js/notes/singlenote/singlenote.html
+++ b/browser/js/notes/singlenote/singlenote.html
@@ -2,7 +2,6 @@
 // Initiate ZenPen
 new zeditor({ wrapperField : document.querySelector('.zp1')});               	      
 new zeditor({ wrapperField : document.querySelector('.zp2')});               	      
-
 </script>
 <div class="muted"> My user id: {{user._id}}</div>
 <div class="alert alert-success" role="alert" ng-if="successmessage">{{successmessage}}</div>
@@ -38,110 +37,31 @@ new zeditor({ wrapperField : document.querySelector('.zp2')});
 					</div>
 				</div>
 			</div>
-			<!-- <div class="form-group"> -->
-
-
-			<div class="form-group">
-<!-- 			
-				<h5>Form control:</h5>
-				<textarea class="form-control" id="notebody" ng-model="currentNote().body">{{currentNote().body}}</textarea> -->
-<!-- 				<h5 class="muted">Note body:</h5>
-				{{currentNote().body}} -->
-				
-				<!-- markdown preview shows below -->
-				<!-- <div marked="currentNote().body" /> -->
-				<!-- end mrkdown preview -->	
-
-			</div>
 
 			<textarea id="notebody" ng-model="currentNote().body" placeholder="{{currentNote().body}}" class="form-control" >
 			</textarea>
 
-<!-- 			<div id="notebody" text="init text" class='iiMdPreview' textarea-class="form-control" textarea-name='currentNote().body' /> -->
-
-
-			<!-- the following lines are for ZENPEN -->
-
-				<!-- <div class="zp2 section yin">      -->
-					<!-- <article id="notebody" contenteditable="true" class="content"> -->
-						<!-- {{currentNote().body}} -->
-					<!-- </article> -->
-				<!-- </div> zen pen end -->
-
-			<!-- END ZENPEN -->
 		</div>
 
-<!-- 			<h4>Markdown preview</h4>
-			<div marked="currentNote().body">
+		<button class="btn btn-primary" ng-click="save()">Save Changes</button>
 
-			</div>
-			<h4> A different preview field</h4>
-			<div class='iiMdPreview' id="notebody" textarea-name='markdown' />
- -->
-			<button class="btn btn-primary" ng-click="save()">Save Changes</button>
+		<div class="alert alert-success" role="alert" ng-if="tagsavesuccess">{{tagsavesuccess}}</div>
 
+		<tagfooter></tagfooter>
+	</div>
 
-		<div class="panel-footer">
-			<h4>Tags</h4>
-				<h5>All tags testing</h5>
-				<div class="list-group">
-					<div class="list-group-item" ng-repeat="tag in currentNote().tags track by $index">{{tag}} 
-						<!-- angular requires index -->
-						{{$index}}
-						<a ng-click="removeTag(currentNote()._id, tag)">
-						<i class="glyphicon glyphicon-remove"> </i>
-						</a>
+	<div class="panel panel-default">
+		<div class="panel-heading">Trash</div>
+		<div class="panel-body">
+		<button ng-click="deleteNote(currentNote()._id)" ng-show="!currentNote().trash" type="button" class="btn btn-danger"  data-toggle="tooltip" title="Delete note">
+			<i class="fa fa-minus-square"> delete note
+			</i>
+		</button>
 
-					</div>
-				</div>
-
-<!-- 			<button ng-repeat="tag in currentNote().tags" class="btn btn-outline btn-default" title="Remove tag">{{tag}} <a ng-click="removeTag(currentNote()._id, tag)">x</a></button>
- -->
-<!-- 			<button ng-if="showTagEditWindow" type="button" class="btn btn-outline btn-default" data-toggle="tooltip" title="Tag to Add"> -->
-<!-- 			<form ng-submit="addTag(currentNote()._id, tagToAdd)">
-			<input class="form-control" ng-model="tagToAdd"></input>
-			</form> -->
-			<!-- </button> -->
-				
-
-			<div class="input-group"> 
-				<span class="input-group-addon">+</span> 
-				<form ng-submit="addTag(currentNote()._id, tagToAdd)">
-				<input ng-model="tagToAdd" type="text" class="form-control" placeholder="Add a tag"> 
-				</form>
-			</div>
-<!-- 
-			<button ng-click="openTagWindow()" type="button" class="btn btn-success btn-circle"  data-toggle="tooltip" title="Add a tag">
-				<i class="fa fa-plus">
-				</i>
-			</button> -->
-
-			</div>
-			<hr />
-			<button ng-click="deleteNote(currentNote()._id)" ng-show="!currentNote().trash" type="button" class="btn btn-danger"  data-toggle="tooltip" title="Delete note">
-				<i class="fa fa-minus-square"> delete note
-				</i>
-			</button>
-
-			<button ng-click="restoreNote(currentNote()._id)" ng-show="currentNote().trash"type="button" class="btn btn-success"  data-toggle="tooltip" title="Restore note">
-				<i class="fa fa-plus-square"> restore from trash
-				</i>
-			</button>
-
-		
-
-
-		<div>
-
-			<p>This area is just for testing. Feel free to delete or comment out.</p>
-			<pre><code>console.log("click HIGHLIGHT-JS button to highlight me")</code></pre>
-			<div id="parentOftestDiv">
-				<div id="testdiv"> function clickHighlightJStoHighlightMe (somestuff) { console.log('I love JS'); }</div>
-			</div>
-			<div class="form-group">
-			<button class="btn btn-default" ng-click="addPre()">Highlight-JS</button>
-
-		</div>
+		<button ng-click="restoreNote(currentNote()._id)" ng-show="currentNote().trash"type="button" class="btn btn-success"  data-toggle="tooltip" title="Restore note">
+			<i class="fa fa-plus-square"> restore from trash
+			</i>
+		</button>
 		</div>
 	</div>
 </div>

--- a/browser/js/notes/singlenote/singlenote.html
+++ b/browser/js/notes/singlenote/singlenote.html
@@ -9,11 +9,11 @@ new zeditor({ wrapperField : document.querySelector('.zp2')});
 <div class="col-lg-8 col-md-8 col-sm-12">
 	<div class="panel panel-default">
 		<div class="panel-heading">
-			<h3>
-			<div class="zp1 section yin">
-				<span class="muted">Note subject:</span> <span id="notesubject" contenteditable="true">	{{currentNote().subject}}</span>
-			</div>
-			</h3>
+
+			<label for="notesubject" class="muted">Note subject:</label> 
+			<input ng-model="currentNote().subject" class="form-control" id="notesubject" placeholder="{{currentNote().subject}}">
+
+
 		</div>
 		<div class="panel-body">
 			<div class="panel panel-default">

--- a/browser/js/notes/singlenote/singlenote.html
+++ b/browser/js/notes/singlenote/singlenote.html
@@ -83,29 +83,48 @@ new zeditor({ wrapperField : document.querySelector('.zp2')});
 
 		<div class="panel-footer">
 			<h4>Tags</h4>
-			<button ng-repeat="tag in currentNote().tags" type="button" class="btn btn-outline btn-default" data-toggle="tooltip" title="Remove tag">{{tag}} <a ng-click="removeTag(currentNote()._id, tag)">x</a></button>
+				<h5>All tags testing</h5>
+				<div class="list-group">
+					<div class="list-group-item" ng-repeat="tag in currentNote().tags track by $index">{{tag}} 
+						<!-- angular requires index -->
+						{{$index}}
+						<a ng-click="removeTag(currentNote()._id, tag)">
+						<i class="glyphicon glyphicon-remove"> </i>
+						</a>
 
-			<button ng-if="openTW" type="button" class="btn btn-outline btn-default" data-toggle="tooltip" title="Tag to Add">
-				<form  ng-submit="addTag(currentNote()._id, tagToAdd)">
-					<input ng-model="tagToAdd"></input>
-				</form>
-			</button>
+					</div>
+				</div>
+
+<!-- 			<button ng-repeat="tag in currentNote().tags" class="btn btn-outline btn-default" title="Remove tag">{{tag}} <a ng-click="removeTag(currentNote()._id, tag)">x</a></button>
+ -->
+<!-- 			<button ng-if="showTagEditWindow" type="button" class="btn btn-outline btn-default" data-toggle="tooltip" title="Tag to Add"> -->
+<!-- 			<form ng-submit="addTag(currentNote()._id, tagToAdd)">
+			<input class="form-control" ng-model="tagToAdd"></input>
+			</form> -->
+			<!-- </button> -->
 				
 
+			<div class="input-group"> 
+				<span class="input-group-addon">+</span> 
+				<form ng-submit="addTag(currentNote()._id, tagToAdd)">
+				<input ng-model="tagToAdd" type="text" class="form-control" placeholder="Add a tag"> 
+				</form>
+			</div>
+<!-- 
 			<button ng-click="openTagWindow()" type="button" class="btn btn-success btn-circle"  data-toggle="tooltip" title="Add a tag">
 				<i class="fa fa-plus">
 				</i>
+			</button> -->
+
+			<button ng-click="deleteNote(currentNote()._id)" ng-show="!currentNote().trash" type="button" class="btn btn-danger"  data-toggle="tooltip" title="Delete note">
+				<i class="fa fa-minus-square"> delete note
+				</i>
 			</button>
 
-				<button ng-click="deleteNote(currentNote()._id)" ng-show="!currentNote().trash" type="button" class="btn btn-danger"  data-toggle="tooltip" title="Delete note">
-						<i class="fa fa-minus-square"> delete note
-						</i>
-				</button>
-
-				<button ng-click="restoreNote(currentNote()._id)" ng-show="currentNote().trash"type="button" class="btn btn-success"  data-toggle="tooltip" title="Restore note">
-						<i class="fa fa-plus-square"> restore from trash
-						</i>
-				</button>
+			<button ng-click="restoreNote(currentNote()._id)" ng-show="currentNote().trash"type="button" class="btn btn-success"  data-toggle="tooltip" title="Restore note">
+				<i class="fa fa-plus-square"> restore from trash
+				</i>
+			</button>
 
 		</div>
 		<hr />

--- a/browser/js/notes/singlenote/singlenote.html
+++ b/browser/js/notes/singlenote/singlenote.html
@@ -47,27 +47,18 @@ new zeditor({ wrapperField : document.querySelector('.zp2')});
 			</div> 
 
 		</div>
+		<div class="panel-body">
 			<button class="btn btn-primary" ng-click="save()">Save Changes</button>
 			<button class="btn btn-primary" ng-click="runTonic()">Open Tonic</button>
-
-
-		<div class="alert alert-success" role="alert" ng-if="tagsavesuccess">{{tagsavesuccess}}</div>
-
-		<tagfooter></tagfooter>
-	</div>
-
-	<div class="panel panel-default">
-		<div class="panel-heading">Trash</div>
-		<div class="panel-body">
-		<button ng-click="deleteNote(currentNote()._id)" ng-show="!currentNote().trash" type="button" class="btn btn-danger"  data-toggle="tooltip" title="Delete note">
-			<i class="fa fa-minus-square"> delete note
-			</i>
-		</button>
-
-		<button ng-click="restoreNote(currentNote()._id)" ng-show="currentNote().trash"type="button" class="btn btn-success"  data-toggle="tooltip" title="Restore note">
-			<i class="fa fa-plus-square"> restore from trash
-			</i>
-		</button>
+			<button ng-click="deleteNote(currentNote()._id)" ng-show="!currentNote().trash" type="button" class="btn btn-danger"  data-toggle="tooltip" title="Delete note">
+				 Delete Note
+			</button>
+			<button ng-click="restoreNote(currentNote()._id)" ng-show="currentNote().trash"type="button" class="btn btn-success"  data-toggle="tooltip" title="Restore note">
+				Restore Note from Trash
+			</button>
 		</div>
+		<div class="alert alert-success" role="alert" ng-if="tagsavesuccess">{{tagsavesuccess}}</div>
+		<tagfooter></tagfooter>
+
 	</div>
 </div>

--- a/browser/js/notes/singlenote/singlenote.html
+++ b/browser/js/notes/singlenote/singlenote.html
@@ -116,6 +116,8 @@ new zeditor({ wrapperField : document.querySelector('.zp2')});
 				</i>
 			</button> -->
 
+			</div>
+			<hr />
 			<button ng-click="deleteNote(currentNote()._id)" ng-show="!currentNote().trash" type="button" class="btn btn-danger"  data-toggle="tooltip" title="Delete note">
 				<i class="fa fa-minus-square"> delete note
 				</i>
@@ -126,8 +128,8 @@ new zeditor({ wrapperField : document.querySelector('.zp2')});
 				</i>
 			</button>
 
-		</div>
-		<hr />
+		
+
 
 		<div>
 

--- a/browser/js/notes/tag.footer/tag.footer.directive.js
+++ b/browser/js/notes/tag.footer/tag.footer.directive.js
@@ -1,0 +1,9 @@
+app.directive('tag.footer', function () {
+
+    return {
+        restrict: 'E',
+        templateUrl: 'js/notes/tag.footer/tag.footer.html',
+        controller: 'SingleNoteCtrl'
+    };
+
+});

--- a/browser/js/notes/tag.footer/tag.footer.directive.js
+++ b/browser/js/notes/tag.footer/tag.footer.directive.js
@@ -1,9 +1,0 @@
-app.directive('tag.footer', function () {
-
-    return {
-        restrict: 'E',
-        templateUrl: 'js/notes/tag.footer/tag.footer.html',
-        controller: 'SingleNoteCtrl'
-    };
-
-});

--- a/browser/js/notes/tagfooter/tagfooter.directive.js
+++ b/browser/js/notes/tagfooter/tagfooter.directive.js
@@ -1,0 +1,9 @@
+app.directive('tagfooter', function () {
+
+    return {
+        restrict: 'E',
+        templateUrl: 'js/notes/tagfooter/tagfooter.html',
+        controller: 'SingleNoteCtrl'
+    };
+
+});

--- a/browser/js/notes/tagfooter/tagfooter.html
+++ b/browser/js/notes/tagfooter/tagfooter.html
@@ -1,0 +1,16 @@
+<div class="panel-footer">
+	<h4>Tags</h4>
+		<ul class="nav nav-pills">
+			<li ng-repeat="tag in currentNote().tags track by $index"><span class="tiny" ng-click="removeTag(currentNote()._id, tag)">{{$index}}</span> 
+				{{tag}} <i class="glyphicon glyphicon-remove"></i>
+			</li>
+		</ul>
+
+	<form ng-submit="addTag(currentNote()._id, tagToAdd)">
+		<div class="input-group"> 
+			<input ng-model="tagToAdd" type="text" class="form-control" placeholder="Add a tag"> 
+			<span ng-click="addTag(currentNote()._id, tagToAdd)" class="input-group-addon">+</span> 
+		</div>
+	</form>
+
+</div>

--- a/browser/scss/capstone.scss
+++ b/browser/scss/capstone.scss
@@ -65,7 +65,7 @@ a.muted {
 	    color: #555;
 	    cursor: pointer;
 	    background-color: #fff;
-	    border: 1px solid #337ab7;
+	    border: 1px solid #888;
 	    border-radius: 4px;
 	    display: block;
 	    position: relative;

--- a/browser/scss/capstone.scss
+++ b/browser/scss/capstone.scss
@@ -47,3 +47,32 @@ a.muted {
 		}
 	}
 }
+
+.panel-footer {
+	.input-group {
+		width: 20%;
+	}
+	.input-group-addon {
+		cursor: pointer;
+	}
+	i.glyphicon {
+		color: red;
+	}
+	.tiny {
+		font-size: 1%;
+	}
+	.nav-pills li {
+	    color: #555;
+	    cursor: pointer;
+	    background-color: #fff;
+	    border: 1px solid #337ab7;
+	    border-radius: 4px;
+	    display: block;
+	    position: relative;
+	    padding: 5px 7px;
+	    &:hover {
+	    	background-color: #555;
+	    	color: #fff;
+	    }
+	}
+}

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -51,7 +51,10 @@ $(document).ready(function(){
       $('textarea').val( request.selection );
   });
 
-  chrome.tabs.executeScript(null, {code: "chrome.extension.sendRequest({selection: window.getSelection().toString() });"});
+  if(chrome.tabs) {
+      chrome.tabs.executeScript(null, {code: "chrome.extension.sendRequest({selection: window.getSelection().toString() });"});
+  }
+
 
 });
 

--- a/server/app/routes/notes/note.tags.js
+++ b/server/app/routes/notes/note.tags.js
@@ -13,8 +13,10 @@ router.get('/', function(req,res, next) {
 
 // Add a new tag to the note
 router.post('/', function(req, res, next) {
+	console.log("^^ routes > notes > note.tags.js > post req body", req.body)
 	req.currentNote.addTag(req.body.tag)
 	.then(function(note) {
+		console.log("^^ routes > notes > note.tags.js > post note response", note)
 		res.json(note);	
 	})
 	.then(null, next)


### PR DESCRIPTION
- Removed ZenPen from Note Subject editing area because if you delete entire subject, it is difficult to get it back in ZenPen. It is now an input text field.
- Add Tag works (to save). It does not update immediately in cache.
- Remove Tag is not hooked up yet.
- moved Delete/Trash buttons next to Save.
- moved Tag Footer into a separate directive to make it easier to read singlenote HTML template
- fixed a minor error in popup.js (related to chrome.tabs not being defined)
- added findParentNotebook method in NotesFactory 
- tried to refactor SingleNote Controller $scope.addTag method to update cache, but it isn't completely working
- removed a bunch of commented-out HTML in SingleNote.html (related to ZenPen and Angular Markdown Preview
