### PR TITLE
Tweak public notes state (closes 123 165 124 166)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ npm-debug.log
 public
 .DS_Store
 coverage
-notes/commit.txt
+notes
 bower_components

--- a/browser/js/notes/notes.factory.js
+++ b/browser/js/notes/notes.factory.js
@@ -179,10 +179,8 @@ app.factory('NotesFactory', function($http, $rootScope, $q) {
 	}
 
 	NotesFactory.fetchMyNotes = function() {
-		
 		return NotesFactory.fetchMyNotebooks()
 		.then(function(notebookCache){
-
 		for (var i = 0; i < notebookCache.length; i++) {
 			notesCache = notesCache.concat(notebookCache[i].notes);
 		}
@@ -191,11 +189,11 @@ app.factory('NotesFactory', function($http, $rootScope, $q) {
 	}
 
 	NotesFactory.fetchPublicNotes = function() {
-    return $http.get('/api/public/notes/all')
-    .then(function(response) {
-        return response.data;
-    })
-  }
+		return $http.get('/api/public/notes')
+		.then(function(response) {
+			return response.data;
+		})
+	}
 
 	// this function is working!
 	NotesFactory.fetchMyTags = function() {
@@ -213,7 +211,6 @@ app.factory('NotesFactory', function($http, $rootScope, $q) {
 	NotesFactory.getNote = function (noteId) {
 		return $http.get('/api/notes/' + noteId)
 		.then(function(response) {
-
 			return response.data;
 		}, function(err) {
 			console.error("could not find note", err)

--- a/browser/js/notes/public-notes/public-notes.html
+++ b/browser/js/notes/public-notes/public-notes.html
@@ -9,6 +9,6 @@
     <div class="list-group-item" ng-repeat="note in publicNotes | filter:searchNotes">
       <h3><a ui-sref="note({id: note._id})">{{note.subject}}</a></h3>
       <div>{{note.body | trunc:true:300:' ...'}}</div>
-      <div><strong>Last updated</strong> {{note.dateCreated}}</div>
+      <div><strong>Last updated</strong> {{note.dateCreated | date: 'longDate'}}</div>
     </div>
 </div>

--- a/browser/js/notes/public-notes/public-notes.js
+++ b/browser/js/notes/public-notes/public-notes.js
@@ -3,7 +3,7 @@ app.config(function ($stateProvider) {
 
   // this is the main state to show user content.
   $stateProvider.state('community', {
-    url: '/public/:searchTerm',
+    url: '/search/:searchTerm',
     templateUrl: 'js/notes/public-notes/public-notes.html',
     controller: 'CommunityCtrl',
     resolve: {

--- a/browser/js/notes/public-notes/public-notes.note.html
+++ b/browser/js/notes/public-notes/public-notes.note.html
@@ -1,7 +1,7 @@
 <div class="container">
-  dbsdoaifhodsl
-  <h3>{{note.subject}}</h3>
+  <h1>{{note.subject}}</h1>
+  <hr />
   <div>{{note.dummy}}</div>
-  <div>{{note.body}}</div>
-  <div><strong>Last updated</strong> {{note.dateCreated}}</div>
+  <div marked="note.body"></div>
+  <div><strong>Last updated</strong> {{note.dateCreated | date: 'longDate'}}</div>
 </div>

--- a/server/app/routes/public-data/index.js
+++ b/server/app/routes/public-data/index.js
@@ -24,7 +24,7 @@ router.delete('/notebooks/all', function(req, res, next) {
 	.then(null, next)
 })
 
-// Find all Notes
+// Find all Notes (public and private)
 router.get('/notes/all', function(req, res, next) {
 	Note.find()
 	.then(function(notes) {


### PR DESCRIPTION
- modify URL that was being called in NotesFactory.fetchPublicNotes()
- add markdown support to public singlenote page (browser > js > notes > public-notes > public-notes.note.html)
- add date filter to public singlenote page
- modify URL path for initial search results (was /public but is now /search/:searchterm)
- public note url remains /public/:noteID
