### PR TITLE
Hide error and success messages

### DIFF
--- a/browser/js/notes/notes.html
+++ b/browser/js/notes/notes.html
@@ -1,4 +1,4 @@
 <!-- <div class="row"> -->
 	<sidenav></sidenav> 
-	<singlenote></singlenote>
+	<singlenote ng-click="hideNotification()"></singlenote>
 <!-- </div> -->

--- a/browser/js/notes/singlenote/singlenote.controller.js
+++ b/browser/js/notes/singlenote/singlenote.controller.js
@@ -17,6 +17,12 @@ app.controller('SingleNoteCtrl', function($scope, NotesFactory, TonicFactory, Gi
     //$scope.currentNotebook = NotesFactory.getCurrentNotebook;
     $scope.showmarkdown = false;
     $scope.successmessage = null;
+
+    // Hide notification upon click anywhere in the single note
+    $scope.hideNotification = function() {
+          $scope.successmessage = null;
+          $scope.errormessage = null;
+    }
    
   
     $scope.removeTag = function(note, tag) {

--- a/browser/js/notes/singlenote/singlenote.html
+++ b/browser/js/notes/singlenote/singlenote.html
@@ -29,7 +29,7 @@
 
 		<div class="tab-pane fade" id="edit" ng-hide="currentNote().trash">
 
-			<h2>Edit Note</h2>
+<!-- 			<h2>Edit Note</h2> -->
 			<div class="panel panel-default">
 				<div class="panel-heading">
 					<label for="notesubject" class="muted">Note title</label> 


### PR DESCRIPTION
Error and success messages disappear after clicking anywhere in the single note
